### PR TITLE
Improve presentation of the DOMViewer tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
 	<version>1.0-SNAPSHOT</version>
 
 	<name>DOMViewer</name>
-	<!-- FIXME change it to the project's website -->
-	<url>http://www.example.com</url>
+	<url>https://github.com/byu-cs329/DOMViewer</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
+		<!-- TODO: Update JDT Core to 3.7.1. Also update Java version-->
 		<jdt.core.version>3.3.0-v_771</jdt.core.version>
 		<exec.mainClass>edu.byu.cs329.dom.DomViewer</exec.mainClass>
 	</properties>

--- a/src/main/java/edu/byu/cs329/dom/DomViewer.java
+++ b/src/main/java/edu/byu/cs329/dom/DomViewer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO.
+ * Generates a HTML file that displays the JDT AST extracted from a Java source file.
  * 
  * @author James Wasson
  * @author Eric Mercer
@@ -32,10 +31,10 @@ public class DomViewer {
   static final Logger log = LoggerFactory.getLogger(DomViewer.class);
 
   /**
-   * TODO.
+   * Given the ASTNode instance, print the HTML tree representation to a file.
    * 
-   * @param node TODO
-   * @param file TODO
+   * @param node The ASTNode instance to print in a tree view.
+   * @param file The file to output the HTML.
    */
   public static void writeDomToFile(ASTNode node, String file) {
     String nodeAsHtml = writeAsHtml2(node);
@@ -86,10 +85,10 @@ public class DomViewer {
   }
 
   /**
-   * TODO.
+   * Recursive function that creates a nested HTML tree.
    * 
-   * @param node TODO
-   * @return TODO
+   * @param node The ASTNode to display.
+   * @return The HTML representation of the ASTNode.
    */
   private static String astNodeAsHtmlInner(ASTNode node) {
 
@@ -100,29 +99,24 @@ public class DomViewer {
 
     output += itemHeader + node.getClass().getSimpleName() + nestedListHeader;
 
-    List<?> properties = node.structuralPropertiesForType();
-    for (Iterator<?> iterator = properties.iterator(); iterator.hasNext();) {
-      Object obj = iterator.next();
-      assert obj instanceof StructuralPropertyDescriptor;
+    for (Object obj : node.structuralPropertiesForType()) {
       StructuralPropertyDescriptor descriptor = (StructuralPropertyDescriptor) obj;
 
       if (descriptor instanceof SimplePropertyDescriptor) {
         
-        SimplePropertyDescriptor simple = (SimplePropertyDescriptor) descriptor;
-        Object value = node.getStructuralProperty(simple);
+        Object value = node.getStructuralProperty(descriptor);
         
-        // JavaDoc is part of the AST and their children have no value
+        // Ignore JavaDoc Property. JavaDoc is part of the AST and their children have no value
         if (value == null) {
           continue;
         }
         
-        output += "<li>" + value.getClass().getSimpleName() + " " + simple.getId() + ": \'"
+        output += "<li>" + value.getClass().getSimpleName() + " " + descriptor.getId() + ": \'"
             + value.toString() + "\'</li>\n";
       
       } else if (descriptor instanceof ChildPropertyDescriptor) {
       
-        ChildPropertyDescriptor child = (ChildPropertyDescriptor) descriptor;
-        ASTNode childNode = (ASTNode) node.getStructuralProperty(child);
+        ASTNode childNode = (ASTNode) node.getStructuralProperty(descriptor);
         if (childNode != null) {
           output += astNodeAsHtmlInner(childNode);
         }
@@ -157,9 +151,8 @@ public class DomViewer {
     try {
       return String.join("\n", Files.readAllLines(Paths.get(path)));
     } catch (IOException ioe) {
-      log.error(ioe.getMessage());
+      throw new RuntimeException("Error reading input file. Check input file path", ioe);
     }
-    return "";
   }
 
   /**
@@ -179,9 +172,9 @@ public class DomViewer {
   }
 
   /**
-   * TODO.
+   * Main method to execute DomViewer.
    * 
-   * @param args TODO
+   * @param args Input file string and output file string.
    */
   public static void main(String[] args) {
     if (args.length != 2) {


### PR DESCRIPTION
## Introduction

Upon discussion with @b13decker, I made some changes to the code logic to modify how the tree is displayed to better match the JDT documentation. 

Before doing so, I removed some redundant code, added JavaDocs, and fail the program if the students provide an incorrect input file path. I made these changes in the first commit and made the changes described below in the second commit. You can consider doing a rebase and merge of this PR instead of the normal merge to preserve this commit history.

Please play around with this PR and let me know what else should be done. 

## Major Changes

In this PR, the DOMViewer would output the tree where each carat that could be expanded is either an ASTNode or a method in the ASTNode that retrieves some property of its parent. This should help students visualize more easily how to mock the AST.

I also added some CSS to make the font of the tree to be monospacing, to help students subconsciously connect the tree to their project implementation.

## Potential issues

Due to the way the properties of the AST were retrieved, there is no guarantee that the method displayed retrieving a specific property is named correctly. Empirically though, my implementation was able to provide the correct getter method name almost all of the time (thanks to Java conventions).

## Example Output

Below is the tree generated from the `src/test/resources/NoAllCaps.java` file (TODO)